### PR TITLE
Specify conan version for building dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 * DRIFT-493: WaveletImage, [PR-21](https://github.com/panda-official/WaveletBuffer/pull/21)
+* Required version for conan, [PR-27](https://github.com/panda-official/WaveletBuffer/pull/27)
 
 ## Release 0.1.1 (2022-07-12)
 

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -4,6 +4,8 @@ from conans import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 from conans.tools import Git
 
+required_conan_version = ">=1.50"
+
 
 class WaveletBufferConan(ConanFile):
     name = "wavelet_buffer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "scikit-build",
     "pybind11>=2.9.2",
     "cmake",
-    "conan",
+    "conan>=1.50",
     "ninja; platform_system!='Windows'"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools >= 42",
     "scikit-build",
-    "pybind11>=2.9.2",
+    "pybind11 >= 2.9.2",
     "cmake",
-    "conan>=1.50",
+    "conan >= 1.50.0",
     "ninja; platform_system!='Windows'"
 ]
 


### PR DESCRIPTION
**Refs** #26 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Currently, we don't specify minimal version of conan to build dependencies. It breaks the build  if it is too old.

### What is the new behavior?

Minimal version is 1.50.

### Does this PR introduce a breaking change?** 

Nope

### Other information:
